### PR TITLE
Cleanup css

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -61,11 +61,8 @@ a {
 }
 
 /* AutoUpdateUrl */
-code {
-  overflow-x: scroll;
-}
-
 .url-snippet {
+  overflow-x: scroll;
   width: 75%;
   margin-left: auto;
   background: white;

--- a/components/autoUpdateUrl.tsx
+++ b/components/autoUpdateUrl.tsx
@@ -6,7 +6,7 @@ export default function AutoUpdateUrl({ url }: { url: string }) {
   return (
     <div>
       <p>AutoUpdateUrl: </p>
-      <code className="url-snippet">{`${url}`}</code>
+      <code className="url-snippet text-black">{`${url}`}</code>
       <button
         onClick={() => {
           navigator.clipboard.writeText(url);

--- a/components/storeBadge.tsx
+++ b/components/storeBadge.tsx
@@ -16,7 +16,8 @@ export default function StoreBadge() {
           target="_blank"
           href="https://play.google.com/store/apps/details?id=com.finoldigital.cardgamesim&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
         >
-          <Image
+          <img
+            // Can't use next/Image for external image
             src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
             width="250"
             height="83"
@@ -29,7 +30,8 @@ export default function StoreBadge() {
           target="_blank"
           href="https://apps.apple.com/us/app/card-game-simulator/id1392877362?itsct=apps_box_badge&amp;itscg=30200"
         >
-          <Image
+          <img
+            // Can't use next/Image for external image
             src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1536624000"
             width="250"
             height="83"
@@ -42,7 +44,8 @@ export default function StoreBadge() {
           target="_blank"
           href="https://apps.apple.com/us/app/card-game-simulator/id1398206553"
         >
-          <Image
+          <img
+            // Can't use next/Image for external image
             src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg"
             width="250"
             height="83"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Style**
  - Updated `.url-snippet` CSS class to include horizontal scrolling
  - Added `text-black` class to URL snippet for improved readability

- **Refactor**
  - Replaced Next.js `Image` component with standard `<img>` tags for external store badges (Google Play, App Store, Mac App Store)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->