### PR TITLE
Flip zip and autoUpdateUrl for game upload and fix tests

### DIFF
--- a/__tests__/uploadGameForm.test.tsx
+++ b/__tests__/uploadGameForm.test.tsx
@@ -70,8 +70,8 @@ describe('UploadGameForm', () => {
 
   it('should show both upload mode tabs when user is authenticated with username', () => {
     renderWithUser({ uid: 'test-uid' }, 'testuser');
-    expect(screen.getByText('Enter AutoUpdate URL')).toBeInTheDocument();
     expect(screen.getByText('Upload .cgs.zip File')).toBeInTheDocument();
+    expect(screen.getByText('Enter AutoUpdate URL')).toBeInTheDocument();
   });
 
   it('should default to ZIP mode', () => {
@@ -91,9 +91,9 @@ describe('UploadGameForm', () => {
     renderWithUser({ uid: 'test-uid' }, 'testuser');
     const user = userEvent.setup();
 
-    await user.click(screen.getByText('Upload .cgs.zip File'));
     await user.click(screen.getByText('Enter AutoUpdate URL'));
-    expect(screen.getByLabelText(/Enter CGS AutoUpdate Url/i)).toBeInTheDocument();
+    await user.click(screen.getByText('Upload .cgs.zip File'));
+    expect(screen.getByLabelText(/Upload .cgs.zip file/i)).toBeInTheDocument();
   });
 
   it('should upload zip files to Storage before requesting server processing', async () => {

--- a/__tests__/uploadGameForm.test.tsx
+++ b/__tests__/uploadGameForm.test.tsx
@@ -74,20 +74,20 @@ describe('UploadGameForm', () => {
     expect(screen.getByText('Upload .cgs.zip File')).toBeInTheDocument();
   });
 
-  it('should default to URL mode', () => {
+  it('should default to ZIP mode', () => {
     renderWithUser({ uid: 'test-uid' }, 'testuser');
-    expect(screen.getByLabelText(/Enter CGS AutoUpdate Url/i)).toBeInTheDocument();
-  });
-
-  it('should switch to zip upload mode when tab is clicked', async () => {
-    renderWithUser({ uid: 'test-uid' }, 'testuser');
-    const user = userEvent.setup();
-
-    await user.click(screen.getByText('Upload .cgs.zip File'));
     expect(screen.getByLabelText(/Upload .cgs.zip file/i)).toBeInTheDocument();
   });
 
-  it('should switch back to URL mode when tab is clicked', async () => {
+  it('should switch to URL mode when tab is clicked', async () => {
+    renderWithUser({ uid: 'test-uid' }, 'testuser');
+    const user = userEvent.setup();
+
+    await user.click(screen.getByText('Enter AutoUpdate URL'));
+    expect(screen.getByLabelText(/Enter CGS AutoUpdate Url/i)).toBeInTheDocument();
+  });
+
+  it('should switch back to ZIP mode when tab is clicked', async () => {
     renderWithUser({ uid: 'test-uid' }, 'testuser');
     const user = userEvent.setup();
 

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -28,8 +28,8 @@ export default function Page() {
           .
         </p>
         <p>
-          You can upload your game by either providing a CGS AutoUpdate Url or by directly uploading
-          a .cgs.zip file exported from CGS:
+          You can upload your game by either uploading a .cgs.zip file exported from CGS or by
+          providing a CGS AutoUpdate Url:
         </p>
         <UploadGameForm />
       </main>

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -27,10 +27,7 @@ export default function Page() {
           </Link>
           .
         </p>
-        <p>
-          You can upload your game by either uploading a .cgs.zip file exported from CGS or by
-          providing a CGS AutoUpdate Url:
-        </p>
+        <p>You can upload your game with either a .cgs.zip file or an AutoUpdate URL:</p>
         <UploadGameForm />
       </main>
       <Footer />

--- a/components/uploadGameForm.tsx
+++ b/components/uploadGameForm.tsx
@@ -37,22 +37,11 @@ function createUploadId() {
 }
 
 function GameUploadForm() {
-  const [mode, setMode] = useState<UploadMode>('url');
+  const [mode, setMode] = useState<UploadMode>('zip');
 
   return (
     <section>
       <div className="mb-4 flex gap-2">
-        <button
-          type="button"
-          onClick={() => setMode('url')}
-          className={`rounded-md px-4 py-2 text-sm font-medium transition ${
-            mode === 'url'
-              ? 'bg-blue-600 text-white'
-              : 'bg-slate-700 text-gray-300 hover:bg-slate-600'
-          }`}
-        >
-          Enter AutoUpdate URL
-        </button>
         <button
           type="button"
           onClick={() => setMode('zip')}
@@ -63,6 +52,17 @@ function GameUploadForm() {
           }`}
         >
           Upload .cgs.zip File
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('url')}
+          className={`rounded-md px-4 py-2 text-sm font-medium transition ${
+            mode === 'url'
+              ? 'bg-blue-600 text-white'
+              : 'bg-slate-700 text-gray-300 hover:bg-slate-600'
+          }`}
+        >
+          Enter AutoUpdate URL
         </button>
       </div>
       {mode === 'url' ? <AutoUpdateUrlForm /> : <ZipUploadForm />}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2308,9 +2308,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2893,9 +2893,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2909,9 +2909,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -2925,9 +2925,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -2941,9 +2941,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
       ],
@@ -2960,9 +2960,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
       ],
@@ -2979,9 +2979,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
       ],
@@ -2998,9 +2998,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
       ],
@@ -3017,9 +3017,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -3033,9 +3033,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -11760,12 +11760,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -11779,14 +11779,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {


### PR DESCRIPTION
This pull request updates the default behavior of the game upload form to default to ZIP file upload mode instead of URL mode. It also updates the UI and related tests to reflect this change, ensuring consistency across the user interface and test suite.

**UI/UX Changes:**

* The default upload mode in `GameUploadForm` is now set to `'zip'`, so users are first presented with the ZIP file upload option when opening the form.
* The button order and labels in `GameUploadForm` have been updated to make "Upload .cgs.zip File" the primary/default tab, with "Enter AutoUpdate URL" as the secondary option.
* The upload instructions in `app/upload/page.tsx` have been reworded for clarity and now mention ZIP file upload first.

**Test Updates:**

* The tests in `uploadGameForm.test.tsx` have been updated to expect ZIP mode as the default and to validate the new tab switching behavior and labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The upload flow now opens in ZIP upload mode by default.
  * Users can still switch to AutoUpdate URL entry from the upload tabs.

* **Bug Fixes**
  * Updated upload page guidance to clearly describe both supported upload options.
  * Aligned automated tests with the new default upload mode and tab behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->