### PR TITLE
Fallback bannerImageUrl to card back image when banner is missing

### DIFF
--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -61,13 +61,21 @@ export async function POST(request: Request) {
       name: cardGameSpecification.name,
       // Fall back to the card back image when the game has no banner image
       bannerImageUrl:
-        cardGameSpecification.bannerImageUrl || cardGameSpecification.cardBackImageUrl || '',
+        cardGameSpecification.bannerImageUrl || cardGameSpecification.cardBackImageUrl,
       autoUpdateUrl: autoUpdateUrl,
       copyright: cardGameSpecification.copyright ? cardGameSpecification.copyright : username,
       uploadedAt: FieldValue.serverTimestamp(),
     };
 
-    const isValidUrl = new URL(game.bannerImageUrl).protocol === 'https:';
+    if (!game.bannerImageUrl) {
+      return NextResponse.json({ error: 'Missing bannerImageUrl!' }, { status: 400 });
+    }
+    let isValidUrl: boolean;
+    try {
+      isValidUrl = new URL(game.bannerImageUrl).protocol === 'https:';
+    } catch {
+      isValidUrl = false;
+    }
     if (!isValidUrl) {
       return NextResponse.json({ error: 'Invalid bannerImageUrl!' }, { status: 400 });
     }

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -49,7 +49,8 @@ export async function POST(request: Request) {
     const response = await fetch(autoUpdateUrl);
     const cardGameSpecification: {
       name: string;
-      bannerImageUrl: string;
+      bannerImageUrl?: string;
+      cardBackImageUrl?: string;
       copyright: string;
     } = await response.json();
 
@@ -58,7 +59,9 @@ export async function POST(request: Request) {
       username: username,
       slug: slug,
       name: cardGameSpecification.name,
-      bannerImageUrl: cardGameSpecification.bannerImageUrl,
+      // Fall back to the card back image when the game has no banner image
+      bannerImageUrl:
+        cardGameSpecification.bannerImageUrl || cardGameSpecification.cardBackImageUrl || '',
       autoUpdateUrl: autoUpdateUrl,
       copyright: cardGameSpecification.copyright ? cardGameSpecification.copyright : username,
       uploadedAt: FieldValue.serverTimestamp(),

--- a/app/api/games/upload/route.ts
+++ b/app/api/games/upload/route.ts
@@ -308,9 +308,10 @@ async function processZipUpload({ uid, username, filename, zipBuffer }: ProcessZ
   const bannerExt = cgsJson.bannerImageFileType || 'png';
   const bannerFile = `Banner.${bannerExt}`;
   const hasBanner = fileExistsInZip(zip, bannerFile, gameRoot);
+  // Fall back to the card back image when the game has no banner image
   const bannerImageUrl = hasBanner
     ? getPublicUrl(bucketName, `${storageBasePath}/${bannerFile}`)
-    : '';
+    : cgsJson.cardBackImageUrl || '';
 
   const game = {
     username,

--- a/openspec/specs/zip-processing/spec.md
+++ b/openspec/specs/zip-processing/spec.md
@@ -112,6 +112,11 @@ After successfully uploading all files to Storage, the server SHALL create a Fir
 - **WHEN** the zip contains a banner image
 - **THEN** the Firestore game document `bannerImageUrl` SHALL be the Firebase Storage public URL for that image
 
+#### Scenario: bannerImageUrl falls back to card back image
+
+- **WHEN** the zip does not contain a banner image but the game has a card back image
+- **THEN** the Firestore game document `bannerImageUrl` SHALL be the card back image URL (the Firebase Storage public URL when the zip contains the card back file, otherwise the `cardBackImageUrl` declared in `cgs.json`)
+
 #### Scenario: Duplicate game name handling
 
 - **WHEN** the user already has a game with the same slug


### PR DESCRIPTION
## Summary
- When a game is uploaded (zip flow) without a `Banner.<ext>` file, the Firestore game document''s `bannerImageUrl` now falls back to the card back image URL (the Storage URL for `CardBack.<ext>` when present in the zip, otherwise the `cardBackImageUrl` declared in `cgs.json`) instead of an empty string.
- Applied the same fallback to the URL-based submission flow, so a game spec with only a `cardBackImageUrl` is no longer rejected for lacking a banner.
- Documented the new fallback scenario in `openspec/specs/zip-processing/spec.md`.

## Test plan
- [x] `npm test` — 75 tests pass
- [x] `npx tsc --noEmit` and `npx eslint app/api/games` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game image handling when a banner image is unavailable.
  * Card back images are now used as a fallback banner image during game creation and uploads.
  * Added support for game configurations that omit banner or card back image fields.

* **Documentation**
  * Documented the fallback behavior for uploaded game files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->