### PR TITLE
Implement fallback for missing banner image to card back image

### DIFF
--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -61,13 +61,21 @@ export async function POST(request: Request) {
       name: cardGameSpecification.name,
       // Fall back to the card back image when the game has no banner image
       bannerImageUrl:
-        cardGameSpecification.bannerImageUrl || cardGameSpecification.cardBackImageUrl || '',
+        cardGameSpecification.bannerImageUrl || cardGameSpecification.cardBackImageUrl,
       autoUpdateUrl: autoUpdateUrl,
       copyright: cardGameSpecification.copyright ? cardGameSpecification.copyright : username,
       uploadedAt: FieldValue.serverTimestamp(),
     };
 
-    const isValidUrl = new URL(game.bannerImageUrl).protocol === 'https:';
+    if (!game.bannerImageUrl) {
+      return NextResponse.json({ error: 'Missing bannerImageUrl!' }, { status: 400 });
+    }
+    let isValidUrl: boolean;
+    try {
+      isValidUrl = new URL(game.bannerImageUrl).protocol === 'https:';
+    } catch {
+      isValidUrl = false;
+    }
     if (!isValidUrl) {
       return NextResponse.json({ error: 'Invalid bannerImageUrl!' }, { status: 400 });
     }

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -49,7 +49,8 @@ export async function POST(request: Request) {
     const response = await fetch(autoUpdateUrl);
     const cardGameSpecification: {
       name: string;
-      bannerImageUrl: string;
+      bannerImageUrl?: string;
+      cardBackImageUrl?: string;
       copyright: string;
     } = await response.json();
 
@@ -58,7 +59,9 @@ export async function POST(request: Request) {
       username: username,
       slug: slug,
       name: cardGameSpecification.name,
-      bannerImageUrl: cardGameSpecification.bannerImageUrl,
+      // Fall back to the card back image when the game has no banner image
+      bannerImageUrl:
+        cardGameSpecification.bannerImageUrl || cardGameSpecification.cardBackImageUrl || '',
       autoUpdateUrl: autoUpdateUrl,
       copyright: cardGameSpecification.copyright ? cardGameSpecification.copyright : username,
       uploadedAt: FieldValue.serverTimestamp(),

--- a/app/api/games/upload/route.ts
+++ b/app/api/games/upload/route.ts
@@ -308,9 +308,10 @@ async function processZipUpload({ uid, username, filename, zipBuffer }: ProcessZ
   const bannerExt = cgsJson.bannerImageFileType || 'png';
   const bannerFile = `Banner.${bannerExt}`;
   const hasBanner = fileExistsInZip(zip, bannerFile, gameRoot);
+  // Fall back to the card back image when the game has no banner image
   const bannerImageUrl = hasBanner
     ? getPublicUrl(bucketName, `${storageBasePath}/${bannerFile}`)
-    : '';
+    : cgsJson.cardBackImageUrl || '';
 
   const game = {
     username,

--- a/openspec/specs/zip-processing/spec.md
+++ b/openspec/specs/zip-processing/spec.md
@@ -112,6 +112,11 @@ After successfully uploading all files to Storage, the server SHALL create a Fir
 - **WHEN** the zip contains a banner image
 - **THEN** the Firestore game document `bannerImageUrl` SHALL be the Firebase Storage public URL for that image
 
+#### Scenario: bannerImageUrl falls back to card back image
+
+- **WHEN** the zip does not contain a banner image but the game has a card back image
+- **THEN** the Firestore game document `bannerImageUrl` SHALL be the card back image URL (the Firebase Storage public URL when the zip contains the card back file, otherwise the `cardBackImageUrl` declared in `cgs.json`)
+
 #### Scenario: Duplicate game name handling
 
 - **WHEN** the user already has a game with the same slug


### PR DESCRIPTION
This pull request updates the handling of game banner images to provide a fallback to the card back image when a banner image is missing. It also improves validation for the `bannerImageUrl` and updates documentation to reflect this new behavior.

**Banner image fallback and validation improvements:**

* The `bannerImageUrl` field is now optional in the card game specification, and the code will use the `cardBackImageUrl` as a fallback if no banner image is provided. [[1]](diffhunk://#diff-749d4884e663f6d37ddbccf1b4c3a4a1a33d971a02e7a484611d9f16133fee58L52-R53) [[2]](diffhunk://#diff-749d4884e663f6d37ddbccf1b4c3a4a1a33d971a02e7a484611d9f16133fee58L61-R78) [[3]](diffhunk://#diff-047727045784a25f8a01c9b6c03f81998bd3e4492fc8a63a50b64fbe98cd9097R311-R314)
* Added validation to ensure that a valid `bannerImageUrl` is present and is a proper HTTPS URL; otherwise, the request is rejected with an appropriate error message.

**Documentation updates:**

* Updated the spec in `openspec/specs/zip-processing/spec.md` to document the new fallback behavior for `bannerImageUrl` when no banner image is present.