### PR TITLE
feat: validate bannerImageUrl matches cgs.json

### DIFF
--- a/validate-games.js
+++ b/validate-games.js
@@ -1,4 +1,6 @@
-// Validates that all game banner image URLs are accessible
+// Validates that all game banner image URLs are accessible,
+// and that each game's bannerImageUrl in the database matches
+// the bannerImageUrl in its cgs.json (fetched via autoUpdateUrl).
 // Usage: node validate-games.js
 
 // Using native fetch API available in Node.js 18+.
@@ -41,34 +43,26 @@ async function main() {
   let failures = [];
   let successCount = 0;
 
-  async function validateBannerUrl(game) {
-    if (!game.bannerImageUrl) {
-      const error = `❌ ${game.name || 'Unknown'} (${game.username || 'Unknown'}/${
-        game.slug || 'Unknown'
-      }) - Missing bannerImageUrl`;
-      failures.push(error);
-      console.log(error);
-      return false;
-    }
-    console.log(`🔗 Checking: ${game.name} (${game.username}/${game.slug})`);
+  function gameLabel(game) {
+    return `${game.name || 'Unknown'} (${game.username || 'Unknown'}/${game.slug || 'Unknown'})`;
+  }
+
+  async function fetchWithRetry(url, options) {
     let lastError = null;
     for (let attempt = 1; attempt <= 3; attempt++) {
       try {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
-        const response = await fetch(game.bannerImageUrl, {
-          method: 'HEAD',
+        const response = await fetch(url, {
+          ...options,
           signal: controller.signal,
           headers: { 'User-Agent': 'CGS-Games-Banner-Validator/1.0' },
         });
         clearTimeout(timeoutId);
         if (response.ok) {
-          console.log(`   ✅ Accessible (HTTP ${response.status})`);
-          successCount++;
-          return true;
-        } else {
-          lastError = `HTTP ${response.status} ${response.statusText}`;
+          return { response };
         }
+        lastError = `HTTP ${response.status} ${response.statusText}`;
       } catch (error) {
         if (error.name === 'AbortError') {
           lastError = `Request timeout (>${TIMEOUT / 1000}s)`;
@@ -77,42 +71,108 @@ async function main() {
         }
       }
       if (attempt < 3) {
-        console.log(`   ⏳ Retry ${attempt} failed for ${game.bannerImageUrl}, retrying...`);
+        console.log(`   ⏳ Retry ${attempt} failed for ${url}, retrying...`);
         await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY));
       }
     }
-    const errorMsg = `❌ ${game.name} (${game.username}/${game.slug}) - ${lastError}: ${game.bannerImageUrl}`;
-    failures.push(errorMsg);
-    console.log(errorMsg);
-    return false;
+    return { error: lastError };
   }
 
-  async function validateAllBanners() {
+  async function validateBannerUrl(game) {
+    if (!game.bannerImageUrl) {
+      const error = `❌ ${gameLabel(game)} - Missing bannerImageUrl`;
+      failures.push(error);
+      console.log(error);
+      return false;
+    }
+    const { error } = await fetchWithRetry(game.bannerImageUrl, { method: 'HEAD' });
+    if (error) {
+      const errorMsg = `❌ ${gameLabel(game)} - ${error}: ${game.bannerImageUrl}`;
+      failures.push(errorMsg);
+      console.log(errorMsg);
+      return false;
+    }
+    console.log(`   ✅ Banner accessible: ${gameLabel(game)}`);
+    return true;
+  }
+
+  async function validateCgsJsonMatch(game) {
+    if (!game.autoUpdateUrl) {
+      const error = `❌ ${gameLabel(game)} - Missing autoUpdateUrl, cannot verify against cgs.json`;
+      failures.push(error);
+      console.log(error);
+      return false;
+    }
+    const { response, error } = await fetchWithRetry(game.autoUpdateUrl, { method: 'GET' });
+    if (error) {
+      const errorMsg = `❌ ${gameLabel(game)} - Failed to fetch cgs.json (${error}): ${game.autoUpdateUrl}`;
+      failures.push(errorMsg);
+      console.log(errorMsg);
+      return false;
+    }
+    let cgsJson;
+    try {
+      cgsJson = await response.json();
+    } catch (err) {
+      const errorMsg = `❌ ${gameLabel(game)} - cgs.json is not valid JSON (${err.message}): ${game.autoUpdateUrl}`;
+      failures.push(errorMsg);
+      console.log(errorMsg);
+      return false;
+    }
+    // The database bannerImageUrl falls back to the card back image when the
+    // cgs.json has no banner image, so apply the same fallback here.
+    const expectedBannerImageUrl = cgsJson.bannerImageUrl || cgsJson.cardBackImageUrl;
+    if (!expectedBannerImageUrl) {
+      const errorMsg = `❌ ${gameLabel(game)} - cgs.json has no bannerImageUrl or cardBackImageUrl: ${game.autoUpdateUrl}`;
+      failures.push(errorMsg);
+      console.log(errorMsg);
+      return false;
+    }
+    if (game.bannerImageUrl !== expectedBannerImageUrl) {
+      const errorMsg = `❌ ${gameLabel(game)} - bannerImageUrl mismatch: database has "${game.bannerImageUrl}" but cgs.json has "${expectedBannerImageUrl}"`;
+      failures.push(errorMsg);
+      console.log(errorMsg);
+      return false;
+    }
+    console.log(`   ✅ Banner matches cgs.json: ${gameLabel(game)}`);
+    return true;
+  }
+
+  async function validateGame(game) {
+    console.log(`🔗 Checking: ${gameLabel(game)}`);
+    const bannerOk = await validateBannerUrl(game);
+    const matchOk = await validateCgsJsonMatch(game);
+    if (bannerOk && matchOk) {
+      successCount++;
+    }
+  }
+
+  async function validateAllGames() {
     console.log('🚀 Starting banner validation...\n');
     const batchSize = 5;
     for (let i = 0; i < games.length; i += batchSize) {
       const batch = games.slice(i, i + batchSize);
-      await Promise.all(batch.map(validateBannerUrl));
+      await Promise.all(batch.map(validateGame));
       if (i + batchSize < games.length) {
         await new Promise((resolve) => setTimeout(resolve, TIMEOUT));
       }
     }
     console.log(`\n📋 Validation Summary:`);
-    console.log(`   ✅ ${successCount} games have accessible banners`);
-    console.log(`   ❌ ${failures.length} games have inaccessible banners`);
+    console.log(`   ✅ ${successCount} games passed all checks`);
+    console.log(`   ❌ ${failures.length} validation failure(s)`);
     if (failures.length > 0) {
-      console.log(`\n🚨 Failed Games:`);
+      console.log(`\n🚨 Failures:`);
       failures.forEach((failure, index) => {
         console.log(`   ${index + 1}. ${failure}`);
       });
-      console.log(`\n💥 Workflow failed due to ${failures.length} inaccessible banner(s)`);
+      console.log(`\n💥 Workflow failed due to ${failures.length} validation failure(s)`);
       process.exit(1);
     } else {
-      console.log(`\n🎉 All game banners are accessible!`);
+      console.log(`\n🎉 All game banners are accessible and match their cgs.json!`);
     }
   }
 
-  await validateAllBanners();
+  await validateAllGames();
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- `validate-games.js` now fetches each game's cgs.json (via its `autoUpdateUrl`) and verifies the database's `bannerImageUrl` matches the spec's `bannerImageUrl`, applying the same card-back fallback the upload endpoints use (`cgsJson.bannerImageUrl || cgsJson.cardBackImageUrl`)
- Missing `autoUpdateUrl`, unreachable/invalid cgs.json, or a mismatched URL are all reported as validation failures
- Consolidated the duplicated retry/timeout fetch logic into a shared `fetchWithRetry` helper used by both the banner-accessibility check and the new consistency check
- Exit behavior unchanged (exit 1 on any failure), so the daily Validate Games workflow needs no changes

## Test plan
- `npm test` — 75 tests pass
- `npm run lint` and Prettier check pass
- Ran `node validate-games.js` against the live API: correctly validates all 55 games and surfaces real data drift (banner URL mismatches between the database and cgs.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)