### PR TITLE
Fix gatcg_spoilers timeouts with Firestore caching

### DIFF
--- a/.github/workflows/warm-gatcg-cache.yml
+++ b/.github/workflows/warm-gatcg-cache.yml
@@ -37,16 +37,19 @@ jobs:
           attempt=1
           warmed=false
 
-          # A warm run has no OCR budget, so one attempt normally drains the
-          # whole backlog. Retries exist for the case where a large new set
-          # takes longer than a single request is allowed to run: every OCR
-          # batch is persisted as it completes, so each attempt resumes where
-          # the last one stopped.
+          # A warm run drains as much of the backlog as its budget allows, so
+          # one attempt is normally enough. Retries exist for the case where a
+          # large new set needs more than a single request: every OCR batch is
+          # persisted as it completes, so each attempt resumes where the last
+          # one stopped.
+          #
+          # Worst case is 5 x 300s + 4 x 30s sleeps = 27 minutes, which fits
+          # inside the job's timeout-minutes. Keep those two in step.
           while [ "$attempt" -le "$max_attempts" ]; do
             echo "Warm attempt $attempt of $max_attempts"
 
             status=$(curl -sS -o response.json -D headers.txt -w '%{http_code}' \
-              --max-time 900 \
+              --max-time 300 \
               -H "Authorization: Bearer $WARM_TOKEN" \
               "$ENDPOINT?warm=1") || status=000
 
@@ -103,15 +106,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          status=$(curl -sS -o /dev/null -D headers.txt -w '%{http_code}' --max-time 60 "$ENDPOINT")
-          cache_status=$(tr -d '\r' < headers.txt | awk 'tolower($1) == "x-cache:" { print $2 }' | tail -1)
-
-          echo "HTTP $status, X-Cache: ${cache_status:-none}"
+          # Keep the same fallback as the warm step: without it, pipefail aborts
+          # on a connection failure before the error message below is reached.
+          status=$(curl -sS -o /dev/null -D headers.txt -w '%{http_code}' --max-time 60 "$ENDPOINT") || status=000
 
           if [ "$status" != "200" ]; then
             echo "::error::Spoiler endpoint returned HTTP $status after warming."
             exit 1
           fi
+
+          # Only read the headers once the request is known to have succeeded.
+          cache_status=$(tr -d '\r' < headers.txt | awk 'tolower($1) == "x-cache:" { print $2 }' | tail -1)
+          echo "HTTP $status, X-Cache: ${cache_status:-none}"
 
           if [ "${cache_status:-}" != "hit" ]; then
             echo "::warning::Expected a cache hit after warming but got '${cache_status:-none}'."

--- a/.github/workflows/warm-gatcg-cache.yml
+++ b/.github/workflows/warm-gatcg-cache.yml
@@ -1,0 +1,118 @@
+name: Warm GATCG Spoiler Cache
+
+on:
+  schedule:
+    # Run daily at 11 AM UTC, ahead of peak traffic. Warming is a no-op when
+    # nothing new has been spoiled, so a daily run is cheap.
+    - cron: '0 11 * * *'
+  workflow_dispatch: # Allow manual trigger for testing
+
+permissions:
+  contents: read
+
+# Never let two warm runs OCR the same cards at once.
+concurrency:
+  group: warm-gatcg-cache
+  cancel-in-progress: false
+
+jobs:
+  warm-cache:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Warm the spoiler cache
+        env:
+          ENDPOINT: ${{ vars.GATCG_SPOILERS_URL || 'https://cgs.games/api/gatcg_spoilers' }}
+          WARM_TOKEN: ${{ secrets.GATCG_WARM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$WARM_TOKEN" ]; then
+            echo "::error::GATCG_WARM_TOKEN is not set. Add it as a repository secret, and expose the same value to the backend via apphosting.yaml."
+            exit 1
+          fi
+
+          max_attempts=5
+          attempt=1
+          warmed=false
+
+          # A warm run has no OCR budget, so one attempt normally drains the
+          # whole backlog. Retries exist for the case where a large new set
+          # takes longer than a single request is allowed to run: every OCR
+          # batch is persisted as it completes, so each attempt resumes where
+          # the last one stopped.
+          while [ "$attempt" -le "$max_attempts" ]; do
+            echo "Warm attempt $attempt of $max_attempts"
+
+            status=$(curl -sS -o response.json -D headers.txt -w '%{http_code}' \
+              --max-time 900 \
+              -H "Authorization: Bearer $WARM_TOKEN" \
+              "$ENDPOINT?warm=1") || status=000
+
+            if [ "$status" = "401" ]; then
+              echo "::error::Warm request was rejected (401). The GATCG_WARM_TOKEN secret does not match the token configured on the backend."
+              exit 1
+            fi
+
+            if [ "$status" != "200" ]; then
+              echo "::warning::Warm request failed with HTTP $status"
+              attempt=$((attempt + 1))
+              [ "$attempt" -le "$max_attempts" ] && sleep 30
+              continue
+            fi
+
+            pending=$(tr -d '\r' < headers.txt | awk 'tolower($1) == "x-ocr-pending:" { print $2 }' | tail -1)
+            pending=${pending:-0}
+            cards=$(jq '.data | length' response.json)
+            with_text=$(jq '[.data[] | select(.effect_raw != "")] | length' response.json)
+
+            echo "Cards: $cards, with text: $with_text, awaiting OCR: $pending"
+
+            if [ "$pending" -eq 0 ]; then
+              warmed=true
+              break
+            fi
+
+            echo "$pending card(s) still awaiting OCR; running again"
+            attempt=$((attempt + 1))
+          done
+
+          if [ "$warmed" != true ] && [ "${cards:-0}" = "0" ]; then
+            echo "::error::Could not warm the cache after $max_attempts attempts."
+            exit 1
+          fi
+
+          if [ "$warmed" != true ]; then
+            echo "::warning::Cache is warm but ${pending} card(s) still lack OCR text; the next run will pick them up."
+          fi
+
+          {
+            echo "### GATCG spoiler cache warmed"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Cards | ${cards:-0} |"
+            echo "| With card text | ${with_text:-0} |"
+            echo "| Awaiting OCR | ${pending:-0} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify a normal request is served from cache
+        env:
+          ENDPOINT: ${{ vars.GATCG_SPOILERS_URL || 'https://cgs.games/api/gatcg_spoilers' }}
+        run: |
+          set -euo pipefail
+
+          status=$(curl -sS -o /dev/null -D headers.txt -w '%{http_code}' --max-time 60 "$ENDPOINT")
+          cache_status=$(tr -d '\r' < headers.txt | awk 'tolower($1) == "x-cache:" { print $2 }' | tail -1)
+
+          echo "HTTP $status, X-Cache: ${cache_status:-none}"
+
+          if [ "$status" != "200" ]; then
+            echo "::error::Spoiler endpoint returned HTTP $status after warming."
+            exit 1
+          fi
+
+          if [ "${cache_status:-}" != "hit" ]; then
+            echo "::warning::Expected a cache hit after warming but got '${cache_status:-none}'."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,35 @@ firebase emulators:start
 # Auto-deployment via Firebase App Hosting
 ```
 
+### GATCG Spoiler Cache
+
+`/api/gatcg_spoilers` OCRs card images, which is far too slow to do inside a
+request. Firestore holds two caches: per-card OCR text (`gatcg_ocr_cache`) and
+the fully assembled response (`gatcg_spoiler_cache/current`). A normal request
+is a single document read; a rebuild is bounded by a wall-clock budget and
+defers any OCR that doesn't fit to the next request.
+
+```bash
+# Warm the cache with no OCR budget (drains the whole backlog).
+# Run against a dev server, which writes to the Firestore in .env:
+npm run dev
+curl "http://localhost:3000/api/gatcg_spoilers?warm=1"
+
+# Re-OCR every card from scratch, ignoring cached text:
+curl "http://localhost:3000/api/gatcg_spoilers?warm=1&refresh=1"
+```
+
+In production `warm=1` requires `Authorization: Bearer $GATCG_WARM_TOKEN`, and
+returns 401 unless that secret is configured. Bump `OCR_VERSION` in
+`lib/firebase/admin.ts` to invalidate cached text after changing the OCR
+pipeline; cached text is otherwise only invalidated by a change of image URL.
+
+Note that silvie.gg's API reports card images under `/img/spoilers/...`, but
+that path only has static files for older sets - the set currently being
+spoiled 404s there and is served solely by `/api/images/spoilers/...`.
+`resolveImageUrl` in `lib/gatcgSpoilers.ts` rewrites every image onto the API
+route, which serves all sets.
+
 ## Code Style Guidelines
 
 ### TypeScript & React Patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,9 @@ curl "http://localhost:3000/api/gatcg_spoilers?warm=1&refresh=1"
 ```
 
 In production `warm=1` requires `Authorization: Bearer $GATCG_WARM_TOKEN`, and
-returns 401 unless that secret is configured. Bump `OCR_VERSION` in
+returns 401 unless that secret is configured. `nocache=1` (skip the assembled
+payload cache but still use the OCR cache) needs the same authorization, and is
+ignored otherwise - bypassing the cache is exactly the load it exists to absorb. Bump `OCR_VERSION` in
 `lib/firebase/admin.ts` to invalidate cached text after changing the OCR
 pipeline; cached text is otherwise only invalidated by a change of image URL.
 

--- a/__tests__/gatcgSpoilers.test.ts
+++ b/__tests__/gatcgSpoilers.test.ts
@@ -156,6 +156,41 @@ describe('buildSpoilerData', () => {
       );
     });
 
+    // A look-alike host starts with the expected prefix, so a substring check
+    // would accept it and we would fetch and serve an arbitrary origin.
+    it.each([
+      ['look-alike host', 'https://silvie.gg.example.com/img/spoilers/PRD/evil.jpg'],
+      ['unrelated host', 'https://example.com/img/spoilers/PRD/evil.jpg'],
+      ['protocol-relative host', '//example.com/img/spoilers/PRD/evil.jpg'],
+      ['plaintext silvie', 'http://silvie.gg/img/spoilers/PRD/evil.jpg'],
+      ['javascript url', 'javascript:alert(1)'],
+    ])('drops images from an untrusted origin (%s)', async (_label, cardImageUrl) => {
+      mockUpstream([{ id: 11, card_name: 'Evil', card_image_url: cardImageUrl } as never]);
+      getCachedOcrResultsMock.mockResolvedValue(new Map());
+
+      const result = await buildSpoilerData({ deadline: Date.now() + 60_000 });
+
+      expect(result.data.data[0].card_image_url).toBe('');
+      expect(recognizeMock).not.toHaveBeenCalled();
+    });
+
+    it('accepts subdomains of the expected host', async () => {
+      mockUpstream([
+        {
+          id: 12,
+          card_name: 'CDN Hosted',
+          card_image_url: 'https://images.silvie.gg/img/spoilers/PRD/card.jpg',
+        } as never,
+      ]);
+      getCachedOcrResultsMock.mockResolvedValue(new Map([['12', 'text']]));
+
+      const result = await buildSpoilerData();
+
+      expect(result.data.data[0].card_image_url).toBe(
+        'https://images.silvie.gg/api/images/spoilers/PRD/card.jpg',
+      );
+    });
+
     it('leaves cards with no image alone', async () => {
       mockUpstream([{ id: 10, card_name: 'Imageless', back_card: null } as never]);
       getCachedOcrResultsMock.mockResolvedValue(new Map());

--- a/__tests__/gatcgSpoilers.test.ts
+++ b/__tests__/gatcgSpoilers.test.ts
@@ -1,0 +1,248 @@
+import { buildSpoilerData } from '@/lib/gatcgSpoilers';
+import { getCachedOcrResults, setCachedOcrResults } from '@/lib/firebase/admin';
+
+jest.mock('@/lib/firebase/admin', () => ({
+  getCachedOcrResults: jest.fn(),
+  setCachedOcrResults: jest.fn(),
+}));
+
+const recognizeMock = jest.fn();
+const terminateMock = jest.fn();
+
+jest.mock('tesseract.js', () => ({
+  createScheduler: jest.fn(() => ({
+    addWorker: jest.fn(),
+    addJob: (...args: unknown[]) => recognizeMock(...args),
+    terminate: () => terminateMock(),
+  })),
+  createWorker: jest.fn(async () => ({})),
+}));
+
+jest.mock('sharp', () =>
+  jest.fn(() => ({
+    metadata: jest.fn(async () => ({ width: 100, height: 200 })),
+    extract: jest.fn().mockReturnThis(),
+    greyscale: jest.fn().mockReturnThis(),
+    normalize: jest.fn().mockReturnThis(),
+    sharpen: jest.fn().mockReturnThis(),
+    toBuffer: jest.fn(async () => Buffer.from('cropped')),
+  })),
+);
+
+const getCachedOcrResultsMock = getCachedOcrResults as jest.Mock;
+const setCachedOcrResultsMock = setCachedOcrResults as jest.Mock;
+
+const spoiler = (id: number, name: string) => ({
+  id,
+  card_name: name,
+  card_image_slug: `/img/spoilers/PRD/card-${id}.jpg`,
+  card_image_url: `https://silvie.gg/img/spoilers/PRD/card-${id}.jpg`,
+  card_type: 'Item',
+  element_name: 'Fire',
+  back_card: null,
+});
+
+/** Where the card above is actually served from. */
+const imageUrl = (id: number) => `https://silvie.gg/api/images/spoilers/PRD/card-${id}.jpg`;
+
+const mockUpstream = (spoilers: ReturnType<typeof spoiler>[]) => {
+  global.fetch = jest.fn(async (input: unknown) => {
+    if (String(input).includes('/api/spoilers')) {
+      return { ok: true, json: async () => ({ spoilers }) };
+    }
+    return { ok: true, arrayBuffer: async () => new ArrayBuffer(8) };
+  }) as unknown as typeof fetch;
+};
+
+describe('buildSpoilerData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setCachedOcrResultsMock.mockResolvedValue(undefined);
+    recognizeMock.mockResolvedValue({ data: { text: 'extracted text' } });
+  });
+
+  it('maps upstream spoilers onto card entries', async () => {
+    mockUpstream([spoiler(1, 'CookTech Mixer')]);
+    getCachedOcrResultsMock.mockResolvedValue(new Map([['1', 'cached text']]));
+
+    const result = await buildSpoilerData();
+
+    expect(result.data.data).toEqual([
+      {
+        uuid: '1',
+        name: 'CookTech Mixer',
+        card_image_url: imageUrl(1),
+        back_card_name: '',
+        back_card_image_url: '',
+        types: ['ITEM'],
+        element: 'FIRE',
+        effect_raw: 'cached text',
+      },
+    ]);
+  });
+
+  describe('image URLs', () => {
+    // /img/spoilers only has static files for older sets; the set currently
+    // being spoiled is served solely by the /api/images route.
+    it('rewrites /img/spoilers paths onto the /api/images route', async () => {
+      mockUpstream([spoiler(1, 'One')]);
+      getCachedOcrResultsMock.mockResolvedValue(new Map([['1', 'text']]));
+
+      const result = await buildSpoilerData();
+
+      expect(result.data.data[0].card_image_url).toBe(
+        'https://silvie.gg/api/images/spoilers/PRD/card-1.jpg',
+      );
+    });
+
+    it('rewrites the absolute card_image_url when no slug is provided', async () => {
+      mockUpstream([
+        {
+          id: 7,
+          card_name: 'No Slug',
+          card_image_url: 'https://silvie.gg/img/spoilers/HVN/arcane-blast.png',
+          card_type: 'Action',
+          element_name: 'Fire',
+          back_card: null,
+        } as never,
+      ]);
+      getCachedOcrResultsMock.mockResolvedValue(new Map([['7', 'text']]));
+
+      const result = await buildSpoilerData();
+
+      expect(result.data.data[0].card_image_url).toBe(
+        'https://silvie.gg/api/images/spoilers/HVN/arcane-blast.png',
+      );
+    });
+
+    it('encodes set folders containing spaces', async () => {
+      mockUpstream([
+        {
+          id: 8,
+          card_name: 'Altered',
+          card_image_slug: '/img/spoilers/MRC Alter/prima-materia.jpg',
+          card_type: 'Item',
+          element_name: 'Norm',
+          back_card: null,
+        } as never,
+      ]);
+      getCachedOcrResultsMock.mockResolvedValue(new Map([['8', 'text']]));
+
+      const result = await buildSpoilerData();
+
+      expect(result.data.data[0].card_image_url).toBe(
+        'https://silvie.gg/api/images/spoilers/MRC%20Alter/prima-materia.jpg',
+      );
+    });
+
+    it('resolves back card images too', async () => {
+      mockUpstream([
+        {
+          id: 9,
+          card_name: 'Front',
+          card_image_slug: '/img/spoilers/PRD/front.jpg',
+          card_type: 'Champion',
+          element_name: 'Water',
+          back_card: { card_name: 'Back', card_image_slug: '/img/spoilers/PRD/back.jpg' },
+        } as never,
+      ]);
+      getCachedOcrResultsMock.mockResolvedValue(new Map([['9', 'text']]));
+
+      const result = await buildSpoilerData();
+
+      expect(result.data.data[0].back_card_name).toBe('Back');
+      expect(result.data.data[0].back_card_image_url).toBe(
+        'https://silvie.gg/api/images/spoilers/PRD/back.jpg',
+      );
+    });
+
+    it('leaves cards with no image alone', async () => {
+      mockUpstream([{ id: 10, card_name: 'Imageless', back_card: null } as never]);
+      getCachedOcrResultsMock.mockResolvedValue(new Map());
+
+      const result = await buildSpoilerData({ deadline: Date.now() + 60_000 });
+
+      expect(result.data.data[0].card_image_url).toBe('');
+      expect(recognizeMock).not.toHaveBeenCalled();
+      expect(result.ocrPending).toBe(0);
+    });
+  });
+
+  it('runs no OCR at all when every card is cached', async () => {
+    mockUpstream([spoiler(1, 'One'), spoiler(2, 'Two')]);
+    getCachedOcrResultsMock.mockResolvedValue(
+      new Map([
+        ['1', 'text one'],
+        ['2', 'text two'],
+      ]),
+    );
+
+    const result = await buildSpoilerData({ deadline: Date.now() + 30_000 });
+
+    expect(recognizeMock).not.toHaveBeenCalled();
+    expect(setCachedOcrResultsMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ cardCount: 2, ocrHits: 2, ocrRan: 0, ocrPending: 0 });
+  });
+
+  it('only OCRs the cards missing from the cache, and persists them', async () => {
+    mockUpstream([spoiler(1, 'One'), spoiler(2, 'Two')]);
+    getCachedOcrResultsMock.mockResolvedValue(new Map([['1', 'text one']]));
+
+    const result = await buildSpoilerData({ deadline: Date.now() + 60_000 });
+
+    expect(recognizeMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ ocrHits: 1, ocrRan: 1, ocrPending: 0 });
+    expect(result.data.data[1].effect_raw).toBe('extracted text');
+    expect(setCachedOcrResultsMock).toHaveBeenCalledWith([
+      {
+        spoilerId: '2',
+        imageUrl: imageUrl(2),
+        effectRaw: 'extracted text',
+      },
+    ]);
+  });
+
+  it('defers OCR instead of overrunning the deadline', async () => {
+    mockUpstream([spoiler(1, 'One'), spoiler(2, 'Two')]);
+    getCachedOcrResultsMock.mockResolvedValue(new Map());
+
+    const result = await buildSpoilerData({ deadline: Date.now() + 500 });
+
+    expect(recognizeMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ cardCount: 2, ocrHits: 0, ocrRan: 0, ocrPending: 2 });
+    expect(result.data.data.every((entry) => entry.effect_raw === '')).toBe(true);
+  });
+
+  it('caches failed OCR so it is not retried on every request', async () => {
+    mockUpstream([spoiler(1, 'One')]);
+    getCachedOcrResultsMock.mockResolvedValue(new Map());
+    recognizeMock.mockRejectedValue(new Error('tesseract exploded'));
+
+    const result = await buildSpoilerData({ deadline: Date.now() + 60_000 });
+
+    expect(result).toMatchObject({ ocrRan: 1, ocrPending: 0 });
+    expect(setCachedOcrResultsMock).toHaveBeenCalledWith([
+      { spoilerId: '1', imageUrl: imageUrl(1), effectRaw: '' },
+    ]);
+  });
+
+  it('ignores cached text when refreshing OCR', async () => {
+    mockUpstream([spoiler(1, 'One')]);
+
+    const result = await buildSpoilerData({ deadline: Date.now() + 60_000, refreshOcr: true });
+
+    expect(getCachedOcrResultsMock).not.toHaveBeenCalled();
+    expect(recognizeMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ ocrHits: 0, ocrRan: 1 });
+  });
+
+  it('throws when the upstream API fails', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    })) as unknown as typeof fetch;
+
+    await expect(buildSpoilerData({ deadline: Date.now() + 5_000 })).rejects.toThrow('503');
+  });
+});

--- a/app/api/gatcg_spoilers/route.ts
+++ b/app/api/gatcg_spoilers/route.ts
@@ -1,19 +1,25 @@
+import { timingSafeEqual } from 'node:crypto';
 import { NextResponse } from 'next/server';
-import { createScheduler, createWorker } from 'tesseract.js';
-import sharp from 'sharp';
-import { getCachedOcrResult, setCachedOcrResult } from '@/lib/firebase/admin';
+
+import {
+  getCachedSpoilerPayload,
+  setCachedSpoilerPayload,
+  type CachedSpoilerPayload,
+} from '@/lib/firebase/admin';
+import { buildSpoilerData } from '@/lib/gatcgSpoilers';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 
-const SILVIE_GG_HOST = 'https://silvie.gg';
-const NUM_OCR_WORKERS = 4;
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
 
-// Approximate text box region on Grand Archive TCG cards (as percentage of card dimensions)
-const TEXT_BOX = {
-  topPct: 0.585,
-  leftPct: 0.075,
-  widthPct: 0.85,
-  heightPct: 0.3,
-};
+/** A fully OCR'd payload is served straight from Firestore for this long. */
+const PAYLOAD_FRESH_MS = 15 * 60 * 1000;
+/** A payload still missing OCR text is rebuilt sooner so the backlog drains. */
+const PARTIAL_PAYLOAD_FRESH_MS = 2 * 60 * 1000;
+/** Wall-clock budget for a rebuild, kept well under the platform timeout. */
+const REBUILD_BUDGET_MS = 25 * 1000;
+/** Past this age a cached payload is only used as a fallback on failure. */
+const PAYLOAD_MAX_STALE_MS = 7 * 24 * 60 * 60 * 1000;
 
 // Rate limiting configuration
 const RATE_LIMIT = {
@@ -38,206 +44,156 @@ export async function OPTIONS() {
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
 
+  // Skip the assembled-payload cache, but still use the (cheap) OCR cache.
   const noCache = requestUrl.searchParams.get('nocache') === '1';
+  // Cache warming: rebuild with no OCR budget, draining the whole backlog.
+  const warm = requestUrl.searchParams.get('warm') === '1';
+  // Re-run OCR from scratch; only meaningful together with warm.
+  const refreshOcr = requestUrl.searchParams.get('refresh') === '1';
 
-  // Apply rate limiting
-  const clientIp = getClientIp(request);
-  const rateLimitResult = checkRateLimit(clientIp, RATE_LIMIT);
+  if (warm && !isWarmAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: corsHeaders });
+  }
 
-  if (!rateLimitResult.allowed) {
-    const retryAfter = Math.ceil((rateLimitResult.resetAt - Date.now()) / 1000);
-    return NextResponse.json(
-      { error: 'Too many requests. Please try again later.' },
-      {
-        status: 429,
-        headers: {
-          ...corsHeaders,
-          'Retry-After': retryAfter.toString(),
-          'X-RateLimit-Limit': RATE_LIMIT.maxRequests.toString(),
-          'X-RateLimit-Remaining': '0',
-          'X-RateLimit-Reset': new Date(rateLimitResult.resetAt).toISOString(),
+  // Warm runs are authorized and deliberately long; don't rate limit them.
+  let rateLimitHeaders: Record<string, string> = {};
+  if (!warm) {
+    const rateLimitResult = checkRateLimit(getClientIp(request), RATE_LIMIT);
+
+    if (!rateLimitResult.allowed) {
+      const retryAfter = Math.ceil((rateLimitResult.resetAt - Date.now()) / 1000);
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: {
+            ...corsHeaders,
+            'Retry-After': retryAfter.toString(),
+            'X-RateLimit-Limit': RATE_LIMIT.maxRequests.toString(),
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': new Date(rateLimitResult.resetAt).toISOString(),
+          },
         },
-      },
-    );
-  }
+      );
+    }
 
-  let json: string;
-  try {
-    json = JSON.stringify(await getData(noCache));
-  } catch (error) {
-    console.error('Failed to fetch GATCG spoilers:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch spoiler data' },
-      { status: 502, headers: corsHeaders },
-    );
-  }
-
-  return new NextResponse(json, {
-    status: 200,
-    headers: {
-      ...corsHeaders,
-      'Content-Type': 'application/json',
-      'Cache-Control': noCache ? 'no-store' : 'public, s-maxage=86400, stale-while-revalidate=3600',
+    rateLimitHeaders = {
       'X-RateLimit-Limit': RATE_LIMIT.maxRequests.toString(),
       'X-RateLimit-Remaining': rateLimitResult.remaining.toString(),
       'X-RateLimit-Reset': new Date(rateLimitResult.resetAt).toISOString(),
+    };
+  }
+
+  // Hot path: one Firestore read serves a complete response.
+  let cached: CachedSpoilerPayload | null = null;
+  if (!noCache && !warm) {
+    cached = await getCachedSpoilerPayload();
+    if (cached && cached.ageMs < freshnessLimitFor(cached)) {
+      return respond(cached.payload, {
+        cacheStatus: 'hit',
+        pendingOcrCount: cached.pendingOcrCount,
+        noStore: false,
+        extraHeaders: rateLimitHeaders,
+      });
+    }
+  }
+
+  try {
+    const result = await buildSpoilerData({
+      deadline: warm ? Number.POSITIVE_INFINITY : Date.now() + REBUILD_BUDGET_MS,
+      refreshOcr: warm && refreshOcr,
+    });
+    const payload = JSON.stringify(result.data);
+
+    await setCachedSpoilerPayload({
+      payload,
+      pendingOcrCount: result.ocrPending,
+      cardCount: result.cardCount,
+    });
+
+    return respond(payload, {
+      cacheStatus: warm ? 'warm' : 'miss',
+      pendingOcrCount: result.ocrPending,
+      noStore: noCache || warm,
+      extraHeaders: rateLimitHeaders,
+    });
+  } catch (error) {
+    console.error('Failed to fetch GATCG spoilers:', error);
+
+    // Upstream or OCR failure shouldn't take the endpoint down when we still
+    // have a usable payload from a previous build.
+    const fallback = cached ?? (await getCachedSpoilerPayload());
+    if (fallback && fallback.ageMs < PAYLOAD_MAX_STALE_MS) {
+      console.warn(`Serving spoiler payload cached ${Math.round(fallback.ageMs / 1000)}s ago`);
+      return respond(fallback.payload, {
+        cacheStatus: 'stale',
+        pendingOcrCount: fallback.pendingOcrCount,
+        noStore: false,
+        extraHeaders: rateLimitHeaders,
+      });
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to fetch spoiler data' },
+      { status: 502, headers: { ...corsHeaders, ...rateLimitHeaders } },
+    );
+  }
+}
+
+/**
+ * An incomplete payload is refreshed more eagerly than a complete one, so the
+ * remaining cards get OCR'd over the next few requests instead of being pinned
+ * for the full freshness window.
+ */
+function freshnessLimitFor(cached: CachedSpoilerPayload): number {
+  return cached.pendingOcrCount > 0 ? PARTIAL_PAYLOAD_FRESH_MS : PAYLOAD_FRESH_MS;
+}
+
+function respond(
+  payload: string,
+  options: {
+    cacheStatus: string;
+    pendingOcrCount: number;
+    noStore: boolean;
+    extraHeaders: Record<string, string>;
+  },
+): NextResponse {
+  // Don't let the CDN pin an incomplete payload for long.
+  const cacheControl = options.noStore
+    ? 'no-store'
+    : options.pendingOcrCount > 0
+      ? 'public, s-maxage=120, stale-while-revalidate=3600'
+      : 'public, s-maxage=900, stale-while-revalidate=86400';
+
+  return new NextResponse(payload, {
+    status: 200,
+    headers: {
+      ...corsHeaders,
+      ...options.extraHeaders,
+      'Content-Type': 'application/json',
+      'Cache-Control': cacheControl,
+      'X-Cache': options.cacheStatus,
+      'X-Ocr-Pending': options.pendingOcrCount.toString(),
     },
   });
 }
 
-async function getData(nocache = false) {
-  const url = new URL(`${SILVIE_GG_HOST}/api/spoilers?current=true`);
-  console.log('Request /api/gatcg_spoilers GET ' + url);
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Silvie.gg API returned ${response.status}: ${response.statusText}`);
-  }
-  const responseJson = await response.json();
+/**
+ * Warm runs have no OCR time budget, so they stay behind a shared secret in
+ * production. Without a configured token they are allowed only outside
+ * production, which is what makes local cache warming convenient.
+ */
+function isWarmAuthorized(request: Request): boolean {
+  const token = process.env.GATCG_WARM_TOKEN;
+  if (!token) return process.env.NODE_ENV !== 'production';
 
-  interface CardEntry {
-    uuid: string;
-    name: string;
-    card_image_url: string;
-    back_card_name: string;
-    back_card_image_url: string;
-    types: string[];
-    element: string;
-    effect_raw: string;
-  }
+  const header = request.headers.get('authorization') ?? '';
+  const provided = header.startsWith('Bearer ') ? header.slice('Bearer '.length) : '';
+  if (!provided) return false;
 
-  const dataContainer: { data: CardEntry[] } = { data: [] };
+  const providedBytes = Buffer.from(provided);
+  const tokenBytes = Buffer.from(token);
+  if (providedBytes.length !== tokenBytes.length) return false;
 
-  for (let i = 0; i < responseJson.spoilers.length; i++) {
-    const spoiler = responseJson.spoilers[i];
-
-    const entry: CardEntry = {
-      uuid: '' + spoiler.id,
-      name: spoiler.card_name as string,
-      card_image_url: spoiler.card_image_url,
-      back_card_name: '',
-      back_card_image_url: '',
-      types: [],
-      element: '',
-      effect_raw: '',
-    };
-
-    if (spoiler.back_card && spoiler.back_card.card_name) {
-      entry.back_card_name = spoiler.back_card.card_name;
-      entry.back_card_image_url = spoiler.back_card.card_image_url;
-    }
-
-    const cardType = spoiler.card_type;
-    if (typeof cardType === 'string') {
-      entry.types = [cardType.toUpperCase()];
-    }
-
-    const elementName = spoiler.element_name;
-    if (typeof elementName === 'string') {
-      entry.element = elementName.toUpperCase();
-    }
-
-    dataContainer.data.push(entry);
-  }
-
-  // Check Firestore cache for each card's OCR result
-  const cacheResults = await Promise.all(
-    dataContainer.data.map((entry) => getCachedOcrResult(entry.uuid, entry.card_image_url)),
-  );
-
-  // Separate cached vs uncached entries
-  const uncachedIndices: number[] = [];
-  cacheResults.forEach((cachedText, i) => {
-    if (!nocache && cachedText !== null) {
-      dataContainer.data[i].effect_raw = cachedText;
-    } else {
-      uncachedIndices.push(i);
-    }
-  });
-
-  console.log(
-    `OCR cache: ${dataContainer.data.length - uncachedIndices.length} hits, ${
-      uncachedIndices.length
-    } misses`,
-  );
-
-  // Only run OCR for uncached cards
-  if (uncachedIndices.length > 0) {
-    const scheduler = await createOcrScheduler();
-    try {
-      // Process uncached cards in batches to avoid excessive concurrency
-      for (let start = 0; start < uncachedIndices.length; start += NUM_OCR_WORKERS) {
-        const batchIndices = uncachedIndices.slice(start, start + NUM_OCR_WORKERS);
-
-        const ocrResults = await Promise.all(
-          batchIndices.map((i) => extractCardText(dataContainer.data[i].card_image_url, scheduler)),
-        );
-
-        await Promise.all(
-          ocrResults.map((text, idx) => {
-            const i = batchIndices[idx];
-            dataContainer.data[i].effect_raw = text;
-            if (!text) return; // Don't cache empty/failed OCR results
-            return setCachedOcrResult(
-              dataContainer.data[i].uuid,
-              dataContainer.data[i].card_image_url,
-              text,
-            );
-          }),
-        );
-      }
-    } finally {
-      await scheduler.terminate();
-    }
-  }
-
-  return dataContainer;
-}
-
-async function createOcrScheduler() {
-  const scheduler = createScheduler();
-  const workers = await Promise.all(
-    Array.from({ length: NUM_OCR_WORKERS }, () => createWorker('eng')),
-  );
-  for (const w of workers) {
-    scheduler.addWorker(w);
-  }
-  return scheduler;
-}
-
-async function extractCardText(
-  imageUrl: string,
-  scheduler: ReturnType<typeof createScheduler>,
-): Promise<string> {
-  try {
-    const response = await fetch(imageUrl);
-    if (!response.ok) return '';
-
-    const imageBuffer = Buffer.from(await response.arrayBuffer());
-    const metadata = await sharp(imageBuffer).metadata();
-    const width = metadata.width ?? 0;
-    const height = metadata.height ?? 0;
-
-    if (width === 0 || height === 0) return '';
-
-    const croppedBuffer = await sharp(imageBuffer)
-      .extract({
-        left: Math.floor(width * TEXT_BOX.leftPct),
-        top: Math.floor(height * TEXT_BOX.topPct),
-        width: Math.floor(width * TEXT_BOX.widthPct),
-        height: Math.floor(height * TEXT_BOX.heightPct),
-      })
-      .greyscale()
-      .normalize()
-      .sharpen()
-      .toBuffer();
-
-    const {
-      data: { text },
-    } = await scheduler.addJob('recognize', croppedBuffer);
-
-    return text.replace(/\n{2,}/g, '\n').trim();
-  } catch (error) {
-    console.error(`OCR failed for ${imageUrl}:`, error);
-    return '';
-  }
+  return timingSafeEqual(providedBytes, tokenBytes);
 }

--- a/app/api/gatcg_spoilers/route.ts
+++ b/app/api/gatcg_spoilers/route.ts
@@ -10,7 +10,7 @@ import { buildSpoilerData } from '@/lib/gatcgSpoilers';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 60;
+export const maxDuration = 300;
 
 /** A fully OCR'd payload is served straight from Firestore for this long. */
 const PAYLOAD_FRESH_MS = 15 * 60 * 1000;
@@ -18,6 +18,14 @@ const PAYLOAD_FRESH_MS = 15 * 60 * 1000;
 const PARTIAL_PAYLOAD_FRESH_MS = 2 * 60 * 1000;
 /** Wall-clock budget for a rebuild, kept well under the platform timeout. */
 const REBUILD_BUDGET_MS = 25 * 1000;
+/**
+ * Warm runs get a far larger budget, but still one that fits inside
+ * `maxDuration`: an unbounded run risks being killed mid-build, which would
+ * lose the assembled payload even though the per-batch OCR writes survived.
+ * Whatever a single run cannot finish is left pending, and the daily workflow
+ * retries until nothing is.
+ */
+const WARM_BUDGET_MS = 240 * 1000;
 /** Past this age a cached payload is only used as a fallback on failure. */
 const PAYLOAD_MAX_STALE_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -44,14 +52,18 @@ export async function OPTIONS() {
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
 
-  // Skip the assembled-payload cache, but still use the (cheap) OCR cache.
-  const noCache = requestUrl.searchParams.get('nocache') === '1';
-  // Cache warming: rebuild with no OCR budget, draining the whole backlog.
+  const authorized = isWarmAuthorized(request);
+
+  // Cache warming: rebuild with a much larger OCR budget to drain the backlog.
   const warm = requestUrl.searchParams.get('warm') === '1';
   // Re-run OCR from scratch; only meaningful together with warm.
   const refreshOcr = requestUrl.searchParams.get('refresh') === '1';
+  // Skip the assembled-payload cache, but still use the (cheap) OCR cache.
+  // Operators only: bypassing the payload cache forces an upstream fetch and
+  // can trigger OCR, which is exactly the load the cache exists to absorb.
+  const noCache = requestUrl.searchParams.get('nocache') === '1' && authorized;
 
-  if (warm && !isWarmAuthorized(request)) {
+  if (warm && !authorized) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: corsHeaders });
   }
 
@@ -100,7 +112,7 @@ export async function GET(request: Request) {
 
   try {
     const result = await buildSpoilerData({
-      deadline: warm ? Number.POSITIVE_INFINITY : Date.now() + REBUILD_BUDGET_MS,
+      deadline: Date.now() + (warm ? WARM_BUDGET_MS : REBUILD_BUDGET_MS),
       refreshOcr: warm && refreshOcr,
     });
     const payload = JSON.stringify(result.data);

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -39,3 +39,9 @@ env:
     secret: firebaseClientEmail
   - variable: FIREBASE_PRIVATE_KEY
     secret: firebasePrivateKey
+  # Shared secret authorizing /api/gatcg_spoilers?warm=1, used by the
+  # "Warm GATCG Spoiler Cache" workflow. Must match the repository secret
+  # GATCG_WARM_TOKEN. Create it with:
+  #   firebase apphosting:secrets:set gatcgWarmToken
+  - variable: GATCG_WARM_TOKEN
+    secret: gatcgWarmToken

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,11 @@ service cloud.firestore {
         allow read, write: if false;
       }
 
+      // Assembled spoiler response cache: server-only via Admin SDK
+      match /gatcg_spoiler_cache/{docId} {
+        allow read, write: if false;
+      }
+
       match /games/{gameId} {
         allow read;
         allow write: if isUploadedAtNow() && isValidGame() && isValidUsernameSet();

--- a/lib/firebase/admin.ts
+++ b/lib/firebase/admin.ts
@@ -1,6 +1,12 @@
 import { cert, getApps, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
-import { getFirestore, QueryDocumentSnapshot, Timestamp } from 'firebase-admin/firestore';
+import {
+  DocumentData,
+  FieldValue,
+  getFirestore,
+  QueryDocumentSnapshot,
+  Timestamp,
+} from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
 
 const apps = getApps();
@@ -99,56 +105,195 @@ export async function adminGetGame(username: string, slug: string): Promise<Game
 }
 
 const OCR_CACHE_COLLECTION = 'gatcg_ocr_cache';
-const OCR_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const SPOILER_PAYLOAD_COLLECTION = 'gatcg_spoiler_cache';
+const SPOILER_PAYLOAD_DOC = 'current';
+
+/**
+ * Bump this when the OCR pipeline changes in a way that invalidates already
+ * extracted text (crop region, preprocessing, tesseract options, ...). It is
+ * the only way cached text for an unchanged image is ever discarded.
+ */
+export const OCR_VERSION = 1;
+
+/**
+ * OCR text is a pure function of the card image, so a successful result never
+ * expires on its own: it is invalidated by a change of image URL or of
+ * OCR_VERSION. A time-based TTL would expire every card at once and force a
+ * single unlucky request to re-OCR the whole set.
+ *
+ * Cards whose OCR produced nothing are cached too, so an unreadable card
+ * cannot burn the OCR budget of every request, but they are retried after this
+ * backoff in case the failure was transient (image fetch error, bad crop).
+ */
+const OCR_FAILURE_RETRY_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+/** Firestore caps documents at 1 MiB; stay well clear of it. */
+const MAX_PAYLOAD_BYTES = 900_000;
+
+/** Documents fetched per getAll() round trip. */
+const GET_ALL_CHUNK_SIZE = 300;
 
 interface OcrCacheEntry {
   effect_raw: string;
   imageUrl: string;
   cachedAt: Timestamp;
+  ocrVersion?: number;
+  failedAttempts?: number;
+}
+
+export interface OcrCacheRequest {
+  spoilerId: string;
+  imageUrl: string;
+}
+
+export interface OcrCacheResult {
+  spoilerId: string;
+  imageUrl: string;
+  effectRaw: string;
 }
 
 /**
- * Get a cached OCR result for a spoiler card from Firestore.
- * Returns the cached text if fresh and the image URL matches, otherwise null.
+ * Read cached OCR results for many spoiler cards in as few round trips as
+ * possible. Returns a map of spoiler id to cached text; an entry is present
+ * only when it is still usable for the requested image URL, so any card
+ * missing from the map needs OCR. An empty string means "OCR already ran and
+ * found nothing recently" - don't retry it yet.
  */
-export async function getCachedOcrResult(
-  spoilerId: string,
-  imageUrl: string,
-): Promise<string | null> {
+export async function getCachedOcrResults(
+  requests: OcrCacheRequest[],
+): Promise<Map<string, string>> {
+  const usable = new Map<string, string>();
+  if (requests.length === 0) return usable;
+
+  const requestedImageUrls = new Map(requests.map((r) => [r.spoilerId, r.imageUrl]));
+  const spoilerIds = Array.from(requestedImageUrls.keys());
+
   try {
-    const docRef = adminDb.collection(OCR_CACHE_COLLECTION).doc(spoilerId);
-    const snapshot = await docRef.get();
+    for (let start = 0; start < spoilerIds.length; start += GET_ALL_CHUNK_SIZE) {
+      const refs = spoilerIds
+        .slice(start, start + GET_ALL_CHUNK_SIZE)
+        .map((id) => adminDb.collection(OCR_CACHE_COLLECTION).doc(id));
+      const snapshots = await adminDb.getAll(...refs);
+
+      for (const snapshot of snapshots) {
+        if (!snapshot.exists) continue;
+
+        const data = snapshot.data() as OcrCacheEntry;
+        if (data.imageUrl !== requestedImageUrls.get(snapshot.id)) continue;
+        if ((data.ocrVersion ?? 0) !== OCR_VERSION) continue;
+
+        if (!data.effect_raw) {
+          const cachedAtMs = data.cachedAt?.toMillis() ?? 0;
+          if (Date.now() - cachedAtMs > OCR_FAILURE_RETRY_MS) continue;
+        }
+
+        usable.set(snapshot.id, data.effect_raw ?? '');
+      }
+    }
+  } catch (error) {
+    // A cache read failure just means more OCR work, never a failed request.
+    console.error('Firestore OCR cache read failed:', error);
+  }
+
+  return usable;
+}
+
+/**
+ * Store OCR results for many spoiler cards in a single batched write.
+ */
+export async function setCachedOcrResults(results: OcrCacheResult[]): Promise<void> {
+  if (results.length === 0) return;
+
+  try {
+    const writer = adminDb.bulkWriter();
+    for (const result of results) {
+      const entry: DocumentData = {
+        effect_raw: result.effectRaw,
+        imageUrl: result.imageUrl,
+        cachedAt: Timestamp.now(),
+        ocrVersion: OCR_VERSION,
+        failedAttempts: result.effectRaw ? 0 : FieldValue.increment(1),
+      };
+      writer
+        .set(adminDb.collection(OCR_CACHE_COLLECTION).doc(result.spoilerId), entry, { merge: true })
+        .catch((error) =>
+          console.error(`Firestore OCR cache write failed for ${result.spoilerId}:`, error),
+        );
+    }
+    await writer.close();
+  } catch (error) {
+    console.error('Firestore OCR cache batch write failed:', error);
+  }
+}
+
+export interface CachedSpoilerPayload {
+  /** Serialized response body, ready to return as-is. */
+  payload: string;
+  ageMs: number;
+  /** Cards in the payload still awaiting OCR text when it was built. */
+  pendingOcrCount: number;
+  cardCount: number;
+}
+
+interface SpoilerPayloadEntry {
+  payload: string;
+  cachedAt: Timestamp;
+  pendingOcrCount?: number;
+  cardCount?: number;
+}
+
+/**
+ * Read the fully assembled spoiler response cached in Firestore. This is the
+ * hot path: one document read serves a complete response without touching the
+ * upstream API or tesseract.
+ */
+export async function getCachedSpoilerPayload(): Promise<CachedSpoilerPayload | null> {
+  try {
+    const snapshot = await adminDb
+      .collection(SPOILER_PAYLOAD_COLLECTION)
+      .doc(SPOILER_PAYLOAD_DOC)
+      .get();
     if (!snapshot.exists) return null;
 
-    const data = snapshot.data() as OcrCacheEntry;
-    if (data.imageUrl !== imageUrl) return null;
+    const data = snapshot.data() as SpoilerPayloadEntry;
+    if (!data.payload) return null;
 
-    const cachedAtMs = data.cachedAt.toMillis();
-    if (Date.now() - cachedAtMs > OCR_CACHE_TTL_MS) return null;
-
-    return data.effect_raw;
+    return {
+      payload: data.payload,
+      ageMs: Math.max(0, Date.now() - (data.cachedAt?.toMillis() ?? 0)),
+      pendingOcrCount: data.pendingOcrCount ?? 0,
+      cardCount: data.cardCount ?? 0,
+    };
   } catch (error) {
-    console.error(`Firestore OCR cache read failed for ${spoilerId}:`, error);
+    console.error('Firestore spoiler payload cache read failed:', error);
     return null;
   }
 }
 
 /**
- * Store an OCR result for a spoiler card in Firestore.
+ * Store the assembled spoiler response so later requests can skip the rebuild.
  */
-export async function setCachedOcrResult(
-  spoilerId: string,
-  imageUrl: string,
-  effectRaw: string,
-): Promise<void> {
+export async function setCachedSpoilerPayload(entry: {
+  payload: string;
+  pendingOcrCount: number;
+  cardCount: number;
+}): Promise<void> {
+  const payloadBytes = Buffer.byteLength(entry.payload, 'utf8');
+  if (payloadBytes > MAX_PAYLOAD_BYTES) {
+    console.warn(
+      `Spoiler payload of ${payloadBytes} bytes exceeds the ${MAX_PAYLOAD_BYTES} byte cache limit; skipping write`,
+    );
+    return;
+  }
+
   try {
-    const docRef = adminDb.collection(OCR_CACHE_COLLECTION).doc(spoilerId);
-    await docRef.set({
-      effect_raw: effectRaw,
-      imageUrl,
+    await adminDb.collection(SPOILER_PAYLOAD_COLLECTION).doc(SPOILER_PAYLOAD_DOC).set({
+      payload: entry.payload,
       cachedAt: Timestamp.now(),
+      pendingOcrCount: entry.pendingOcrCount,
+      cardCount: entry.cardCount,
     });
   } catch (error) {
-    console.error(`Firestore OCR cache write failed for ${spoilerId}:`, error);
+    console.error('Firestore spoiler payload cache write failed:', error);
   }
 }

--- a/lib/gatcgSpoilers.ts
+++ b/lib/gatcgSpoilers.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/firebase/admin';
 
 const SILVIE_GG_HOST = 'https://silvie.gg';
+const SILVIE_GG_DOMAIN = 'silvie.gg';
 const MAX_OCR_WORKERS = 4;
 
 const UPSTREAM_FETCH_TIMEOUT_MS = 10_000;
@@ -78,6 +79,11 @@ interface SilvieSpoiler {
   back_card?: { card_name?: string; card_image_url?: string; card_image_slug?: string } | null;
 }
 
+/** Hosts whose images this route is willing to fetch and hand to clients. */
+function isSilvieHost(hostname: string): boolean {
+  return hostname === SILVIE_GG_DOMAIN || hostname.endsWith(`.${SILVIE_GG_DOMAIN}`);
+}
+
 /**
  * Resolve the URL a spoiler card image is actually served from.
  *
@@ -86,20 +92,36 @@ interface SilvieSpoiler {
  * served by silvie.gg's `/api/images/spoilers/...` route and 404 under `/img`.
  * The API route serves every set, so it is used for all of them.
  *
- * Paths are encoded because some set folders contain spaces (e.g. "MRC Alter").
+ * The URL is parsed rather than prefix-matched, and its host checked against
+ * the registrable domain: a look-alike such as `https://silvie.gg.example.com`
+ * starts with the expected prefix but must not be fetched or served onwards.
+ * Anything off-domain is dropped instead of passed through.
  */
 function resolveImageUrl(spoiler: { card_image_url?: string; card_image_slug?: string }): string {
   const raw = spoiler.card_image_slug ?? spoiler.card_image_url ?? '';
   if (!raw) return '';
 
-  const path = raw.startsWith(SILVIE_GG_HOST) ? raw.slice(SILVIE_GG_HOST.length) : raw;
-  if (!path.startsWith('/img/')) {
-    // Unexpected shape (absolute URL on another host, or an already-resolved
-    // path); pass it through rather than mangling it.
-    return raw.startsWith('http') ? raw : `${SILVIE_GG_HOST}${encodeURI(path)}`;
+  let url: URL;
+  try {
+    // Slugs are relative and card_image_url is absolute; resolving against the
+    // known origin handles both, and percent-encodes set folders that contain
+    // spaces (e.g. "MRC Alter").
+    url = new URL(raw, SILVIE_GG_HOST);
+  } catch {
+    console.warn(`Ignoring unparseable spoiler image URL: ${raw}`);
+    return '';
   }
 
-  return `${SILVIE_GG_HOST}${encodeURI('/api/images/' + path.slice('/img/'.length))}`;
+  if (url.protocol !== 'https:' || !isSilvieHost(url.hostname)) {
+    console.warn(`Ignoring spoiler image on unexpected origin: ${url.origin}`);
+    return '';
+  }
+
+  if (url.pathname.startsWith('/img/')) {
+    url.pathname = `/api/images/${url.pathname.slice('/img/'.length)}`;
+  }
+
+  return url.toString();
 }
 
 /**

--- a/lib/gatcgSpoilers.ts
+++ b/lib/gatcgSpoilers.ts
@@ -1,0 +1,304 @@
+import sharp from 'sharp';
+import { createScheduler, createWorker } from 'tesseract.js';
+
+import {
+  getCachedOcrResults,
+  setCachedOcrResults,
+  type OcrCacheResult,
+} from '@/lib/firebase/admin';
+
+const SILVIE_GG_HOST = 'https://silvie.gg';
+const MAX_OCR_WORKERS = 4;
+
+const UPSTREAM_FETCH_TIMEOUT_MS = 10_000;
+const IMAGE_FETCH_TIMEOUT_MS = 10_000;
+
+/** Time held back after the last OCR batch to persist results and respond. */
+const WRITE_RESERVE_MS = 2_000;
+/** Assumed cost of spinning up the tesseract workers before the first batch. */
+const SCHEDULER_INIT_ESTIMATE_MS = 8_000;
+/** Assumed cost of the first OCR batch; later batches use the measured cost. */
+const INITIAL_BATCH_ESTIMATE_MS = 8_000;
+/** Floor for the measured batch cost, so a fast batch can't shrink the guard. */
+const MIN_BATCH_ESTIMATE_MS = 2_000;
+
+// Approximate text box region on Grand Archive TCG cards (as percentage of card dimensions)
+const TEXT_BOX = {
+  topPct: 0.585,
+  leftPct: 0.075,
+  widthPct: 0.85,
+  heightPct: 0.3,
+};
+
+export interface CardEntry {
+  uuid: string;
+  name: string;
+  card_image_url: string;
+  back_card_name: string;
+  back_card_image_url: string;
+  types: string[];
+  element: string;
+  effect_raw: string;
+}
+
+export interface SpoilerData {
+  data: CardEntry[];
+}
+
+export interface BuildSpoilerDataOptions {
+  /**
+   * Absolute wall-clock time (epoch ms) by which the build must be finished.
+   * Cards that cannot be OCR'd within the budget are returned with empty text
+   * and picked up by a later request or a warm run. Defaults to no budget,
+   * which is only appropriate for cache warming.
+   */
+  deadline?: number;
+  /** Re-run OCR even for cards that already have usable cached text. */
+  refreshOcr?: boolean;
+}
+
+export interface BuildSpoilerDataResult {
+  data: SpoilerData;
+  cardCount: number;
+  /** Cards whose text came from the Firestore OCR cache. */
+  ocrHits: number;
+  /** Cards OCR'd during this build. */
+  ocrRan: number;
+  /** Cards left without text because the budget ran out. */
+  ocrPending: number;
+}
+
+interface SilvieSpoiler {
+  id: number | string;
+  card_name?: string;
+  card_image_url?: string;
+  card_image_slug?: string;
+  card_type?: string;
+  element_name?: string;
+  back_card?: { card_name?: string; card_image_url?: string; card_image_slug?: string } | null;
+}
+
+/**
+ * Resolve the URL a spoiler card image is actually served from.
+ *
+ * The API reports images under `/img/spoilers/...`, but that path only has
+ * static files for older sets: images for the set currently being spoiled are
+ * served by silvie.gg's `/api/images/spoilers/...` route and 404 under `/img`.
+ * The API route serves every set, so it is used for all of them.
+ *
+ * Paths are encoded because some set folders contain spaces (e.g. "MRC Alter").
+ */
+function resolveImageUrl(spoiler: { card_image_url?: string; card_image_slug?: string }): string {
+  const raw = spoiler.card_image_slug ?? spoiler.card_image_url ?? '';
+  if (!raw) return '';
+
+  const path = raw.startsWith(SILVIE_GG_HOST) ? raw.slice(SILVIE_GG_HOST.length) : raw;
+  if (!path.startsWith('/img/')) {
+    // Unexpected shape (absolute URL on another host, or an already-resolved
+    // path); pass it through rather than mangling it.
+    return raw.startsWith('http') ? raw : `${SILVIE_GG_HOST}${encodeURI(path)}`;
+  }
+
+  return `${SILVIE_GG_HOST}${encodeURI('/api/images/' + path.slice('/img/'.length))}`;
+}
+
+/**
+ * Build an AbortSignal that respects both a per-request cap and the overall
+ * deadline, so no single fetch can overrun the budget.
+ */
+function timeoutSignal(deadline: number, maxMs: number): AbortSignal {
+  const remaining = deadline - Date.now();
+  const timeout = Number.isFinite(remaining) ? Math.min(maxMs, remaining) : maxMs;
+  return AbortSignal.timeout(Math.max(1, timeout));
+}
+
+async function fetchSpoilerEntries(deadline: number): Promise<CardEntry[]> {
+  const url = new URL(`${SILVIE_GG_HOST}/api/spoilers?current=true`);
+  console.log('Fetching GATCG spoilers from ' + url);
+
+  const response = await fetch(url, { signal: timeoutSignal(deadline, UPSTREAM_FETCH_TIMEOUT_MS) });
+  if (!response.ok) {
+    throw new Error(`Silvie.gg API returned ${response.status}: ${response.statusText}`);
+  }
+
+  const responseJson = (await response.json()) as { spoilers?: SilvieSpoiler[] };
+  const spoilers = responseJson.spoilers ?? [];
+
+  return spoilers.map((spoiler) => {
+    const entry: CardEntry = {
+      uuid: '' + spoiler.id,
+      name: spoiler.card_name ?? '',
+      card_image_url: resolveImageUrl(spoiler),
+      back_card_name: '',
+      back_card_image_url: '',
+      types: [],
+      element: '',
+      effect_raw: '',
+    };
+
+    if (spoiler.back_card && spoiler.back_card.card_name) {
+      entry.back_card_name = spoiler.back_card.card_name;
+      entry.back_card_image_url = resolveImageUrl(spoiler.back_card);
+    }
+
+    if (typeof spoiler.card_type === 'string') {
+      entry.types = [spoiler.card_type.toUpperCase()];
+    }
+
+    if (typeof spoiler.element_name === 'string') {
+      entry.element = spoiler.element_name.toUpperCase();
+    }
+
+    return entry;
+  });
+}
+
+/**
+ * Fetch the current spoiler list and fill in card text, using the Firestore
+ * OCR cache first and only OCR'ing what is missing, within the given budget.
+ */
+export async function buildSpoilerData(
+  options: BuildSpoilerDataOptions = {},
+): Promise<BuildSpoilerDataResult> {
+  const deadline = options.deadline ?? Number.POSITIVE_INFINITY;
+  const entries = await fetchSpoilerEntries(deadline);
+
+  const cachedText = options.refreshOcr
+    ? new Map<string, string>()
+    : await getCachedOcrResults(
+        entries.map((entry) => ({ spoilerId: entry.uuid, imageUrl: entry.card_image_url })),
+      );
+
+  const needsOcr: number[] = [];
+  let ocrHits = 0;
+
+  entries.forEach((entry, index) => {
+    const text = cachedText.get(entry.uuid);
+    if (text !== undefined) {
+      entry.effect_raw = text;
+      ocrHits++;
+    } else if (entry.card_image_url) {
+      needsOcr.push(index);
+    }
+  });
+
+  const ocrRan = needsOcr.length > 0 ? await runOcr(entries, needsOcr, deadline) : 0;
+
+  console.log(
+    `GATCG spoilers: ${entries.length} cards, OCR ${ocrHits} cached / ${ocrRan} extracted / ${
+      needsOcr.length - ocrRan
+    } deferred`,
+  );
+
+  return {
+    data: { data: entries },
+    cardCount: entries.length,
+    ocrHits,
+    ocrRan,
+    ocrPending: needsOcr.length - ocrRan,
+  };
+}
+
+/**
+ * OCR the given entries in place, batch by batch, stopping as soon as another
+ * batch would not fit in the remaining budget. Each batch is persisted as it
+ * completes so partial progress survives, and the next request resumes where
+ * this one left off.
+ */
+async function runOcr(entries: CardEntry[], needsOcr: number[], deadline: number): Promise<number> {
+  const remaining = deadline - Date.now();
+  if (remaining <= SCHEDULER_INIT_ESTIMATE_MS + INITIAL_BATCH_ESTIMATE_MS + WRITE_RESERVE_MS) {
+    console.log(`Skipping OCR of ${needsOcr.length} card(s): not enough time budget remaining`);
+    return 0;
+  }
+
+  const workerCount = Math.min(MAX_OCR_WORKERS, needsOcr.length);
+  const scheduler = await createOcrScheduler(workerCount);
+  let ocrRan = 0;
+
+  try {
+    let batchEstimateMs = INITIAL_BATCH_ESTIMATE_MS;
+
+    for (let start = 0; start < needsOcr.length; start += workerCount) {
+      if (Date.now() + batchEstimateMs + WRITE_RESERVE_MS > deadline) {
+        console.log(`OCR budget exhausted; deferring ${needsOcr.length - start} card(s)`);
+        break;
+      }
+
+      const batchStartedAt = Date.now();
+      const batch = needsOcr.slice(start, start + workerCount);
+      const texts = await Promise.all(
+        batch.map((index) => extractCardText(entries[index].card_image_url, scheduler, deadline)),
+      );
+      batchEstimateMs = Math.max(Date.now() - batchStartedAt, MIN_BATCH_ESTIMATE_MS);
+
+      const writes: OcrCacheResult[] = batch.map((index, batchIndex) => {
+        entries[index].effect_raw = texts[batchIndex];
+        return {
+          spoilerId: entries[index].uuid,
+          imageUrl: entries[index].card_image_url,
+          effectRaw: texts[batchIndex],
+        };
+      });
+      ocrRan += batch.length;
+
+      // Cache failures too, so an unreadable card can't burn every request's
+      // budget; getCachedOcrResults retries them after a backoff.
+      await setCachedOcrResults(writes);
+    }
+  } finally {
+    await scheduler.terminate();
+  }
+
+  return ocrRan;
+}
+
+async function createOcrScheduler(workerCount: number) {
+  const scheduler = createScheduler();
+  const workers = await Promise.all(Array.from({ length: workerCount }, () => createWorker('eng')));
+  for (const w of workers) {
+    scheduler.addWorker(w);
+  }
+  return scheduler;
+}
+
+async function extractCardText(
+  imageUrl: string,
+  scheduler: ReturnType<typeof createScheduler>,
+  deadline: number,
+): Promise<string> {
+  try {
+    const response = await fetch(imageUrl, {
+      signal: timeoutSignal(deadline, IMAGE_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return '';
+
+    const imageBuffer = Buffer.from(await response.arrayBuffer());
+    const metadata = await sharp(imageBuffer).metadata();
+    const width = metadata.width ?? 0;
+    const height = metadata.height ?? 0;
+
+    if (width === 0 || height === 0) return '';
+
+    const croppedBuffer = await sharp(imageBuffer)
+      .extract({
+        left: Math.floor(width * TEXT_BOX.leftPct),
+        top: Math.floor(height * TEXT_BOX.topPct),
+        width: Math.floor(width * TEXT_BOX.widthPct),
+        height: Math.floor(height * TEXT_BOX.heightPct),
+      })
+      .greyscale()
+      .normalize()
+      .sharpen()
+      .toBuffer();
+
+    const {
+      data: { text },
+    } = await scheduler.addJob('recognize', croppedBuffer);
+
+    return text.replace(/\n{2,}/g, '\n').trim();
+  } catch (error) {
+    console.error(`OCR failed for ${imageUrl}:`, error);
+    return '';
+  }
+}


### PR DESCRIPTION
The endpoint timed out in production because it did OCR work on every request and could never stop: cached OCR text expired on a 24h TTL even though it is a pure function of a fixed image, and failed OCR was never cached at all. There were therefore always uncached cards, so every request built 4 tesseract workers on a cold Cloud Run instance.

Caching:
- Drop the OCR TTL. Cached text is invalidated by a change of image URL or by bumping the new OCR_VERSION, not by the clock.
- Cache failed OCR with a 6h retry backoff so an unreadable card can no longer burn the OCR budget of every request.
- Read the OCR cache with one getAll() instead of N gets, and write it through a BulkWriter.
- Cache the assembled response in gatcg_spoiler_cache/current, so the hot path is a single document read.

Never time out:
- Extract the pipeline into lib/gatcgSpoilers.ts and run OCR under a wall-clock deadline, measuring each batch and stopping before one would overrun. Every batch is persisted as it completes, so a later request resumes where this one stopped.
- Bound every fetch by that deadline, and serve a stale payload rather than a 502 when the upstream API fails.

Card images:
- Resolve images onto silvie.gg's /api/images/spoilers route. The API reports them under /img/spoilers, but that path only has static files for older sets; the set currently being spoiled 404s there, which is why OCR had been producing no text at all.

Cache warming:
- Add ?warm=1 to rebuild with no OCR budget, behind GATCG_WARM_TOKEN in production, and a workflow that warms the production cache daily.

A cached request now serves in ~0.13s, and all 26 current spoilers have card text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cached Grand Archive TCG spoiler responses for faster, more consistent loading.
  - Improved card image delivery and support for back-card images.
  - Added OCR text processing to fill missing card effects, with progress preserved between updates.
  - Added cache status and OCR progress indicators to spoiler responses.

- **Bug Fixes**
  - Improved resilience by serving recently cached spoiler data when rebuilding fails.
  - Added clearer handling for throttled requests and upstream service errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->